### PR TITLE
コマンドライン引数にテストスクリプトファイル指定機能と複数パス指定機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,30 @@ hsptestをコマンドラインからhsptestを実行する場合は、以下の
 
 ## コマンドラインからの使い方
 
-以下のコマンドでhsptestを実行できます。
+以下のコマンドでhsptestを実行できます。  
 
-```
+```powershell
 hsptest
 ```
 
+引数無しでhsptestを実行すると、実行したカレントディレクトリ内の全てのテストスクリプト（ファイル名にtestが含まれるhspスクリプトファイル）を実行し、テストします。
+
 テストスクリプトが別のフォルダに置かれてある場合は、そのフォルダを引数で指定することができます。
 
-```
+```powershell
 hsptest path/to/testfolder
+```
+
+引数にはテストスクリプトを直接指定することもでき、その場合は指定したスクリプト内のテストのみを実行します。
+
+```powershell
+hsptest path/to/test.hsp # test.hsp内のテストのみを実行
+```
+
+引数にはディレクトリまたはファイルを複数指定することもできます。
+
+```powershell
+hsptest path/to/testfolder1 path/to/testfolder2 # testfolder1とtestfolder2の中身を連続でテストする
 ```
 
 ### コマンドラインオプション

--- a/argparse.hsp
+++ b/argparse.hsp
@@ -135,6 +135,14 @@
     return argument_value(arg)
 
 /*
+引数の数（オプションを除く）を返す
+返り値
+    引数の数
+*/
+#defcfunc get_arg_num
+    return detected_args
+
+/*
 オプションがコマンドライン引数内に存在しているかを判定する
 引数
     arg_name: オプション名

--- a/hsptest.hsp
+++ b/hsptest.hsp
@@ -7,6 +7,7 @@
 #cfunc timeGetTime "timeGetTime"
 #uselib "shlwapi.dll"
 #cfunc global PathIsRelativeA "PathIsRelativeA" sptr
+#cfunc global PathRelativePathToA "PathRelativePathToA" sptr, sptr, sptr, sptr, sptr
 
 #include "hspdef.as"
 #include "exception_code.as"
@@ -50,17 +51,17 @@ options = {"
 --stop --stop 0
 --version --version 0
 "}
-parse_args 1, options, dir_cmdline
+parse_args 32, options, dir_cmdline
 
 // for debug
 onerror goto *hsptest_error
 
 // show usage
 if is_exist_option("--help") {
-    mes "usage: hsptest [options] [path_to_test_dir]"
+    mes "usage: hsptest [options] [file_or_directory_path(s)]"
     mes ""
     mes "arguments:"
-    mes "  path_to_test_dir       the path to the directory containing the files you want to run the tests"
+    mes "  file_or_directory_path(s)    the path(s) to the script file or directory containing the files you want to run the tests"
     mes ""
     mes "options:"
     mes "  -v, --verbose          print the result for each test"
@@ -86,18 +87,49 @@ if is_exist_option("--runtime") && is_valid_runtime_name(get_option_arg("--runti
     end -1
 }
 
-// change cwd to test directory
+// extract test scripts
+file_num = 0
 first_cwd = dir_cur
-if get_arg(0) != "" {
-    if exist_dir(get_arg(0)) == 0 {
-        color_mes "hsptest: error: directory " + get_arg(0) + " is an invalid path", 0, FOREGROUND_RED
+search_entry_num = get_arg_num()
+if search_entry_num == 0 : search_entry_num = 1
+repeat search_entry_num
+    entry = get_arg(cnt)
+    if entry == "" {
+        if cnt == 0 {
+            entry = "."
+        } else {
+            continue
+        }
+    }
+
+    exist entry
+    if strsize == -1 && exist_dir(entry) == 0 {
+        color_mes "hsptest: error: directory " + entry + " is an invalid path", 0, FOREGROUND_RED
         end -1
     }
-    chdir get_arg(0)
-}
-dirlist testcodes, "*.hsp", 1
-notesel testcodes
-file_num = notemax
+
+    if strsize != -1 {
+        // 表示されるファイル名の整形
+        sdim rel_path, 260
+        abs_pathes = get_absolute_path("."), get_absolute_path(entry)
+        a = PathRelativePathToA(varptr(rel_path), abs_pathes(0), 0x10, abs_pathes(1), 0)
+        strrep rel_path, "\\", "/" // バックスラッシュをパスのデリミタにすると、テストルーチン呼び出しスクリプトのinclude文に突っ込んだときにエスケープシーケンスと誤認されるため、デリミタをスラッシュに置換する
+        strrep rel_path, "./", ""
+        notesel testcodes
+        noteadd rel_path + ";" + getpath(entry, 32)
+        file_num += 1
+    } else {
+        testcodes_in_dir = ""
+        notesel testcodes_in_dir
+        chdir entry
+        dirlist testcodes_in_dir, "*.hsp", 1
+        chdir first_cwd
+        strrep testcodes_in_dir, "\n", ";" + entry + "\n"
+        file_num += notemax + 1
+        notesel testcodes
+        noteadd testcodes_in_dir
+    }
+loop
 
 // output first message
 centered_mes " test session starts ", FOREGROUND_WHITE, "="
@@ -117,8 +149,12 @@ label_pattern = "^(?:.*:)?[ \\t]*(\\*test\\w*)[^\\r]*$"
 all_test_num = 0
 repeat file_num
     notesel testcodes
-    noteget file_name, cnt
+    noteget file_name_and_cwd, cnt
+    if strtrim(file_name_and_cwd) == "" : continue
+    split file_name_and_cwd, ";", file_name, code_cwd
     if strlen(match(file_name, "test")) == 0 : continue
+    chdir first_cwd
+    chdir code_cwd
     notesel testcode_buf
     noteload file_name
     remove_unused_data tmp, testcode_buf
@@ -153,8 +189,13 @@ repeat file_num
 
     // continue if file is not test
     notesel testcodes
-    noteget file_name, cnt
+    noteget file_name_and_cwd, cnt
+    split file_name_and_cwd, ";", file_name, code_cwd
     if strlen(match(file_name, "test")) == 0 : continue
+
+    // change cwd to code directory
+    chdir first_cwd
+    chdir code_cwd
 
     notesel testcode_buf
     noteload file_name

--- a/util.hsp
+++ b/util.hsp
@@ -85,6 +85,12 @@ HSP3ランタイムからそのバージョンを取得する
 #defcfunc none_drive_letter str fullpath
     return replace(fullpath, "[A-Z]:\\\\", "")
 
+#defcfunc get_absolute_path str path, local full_path
+    offset = 0
+    sdim full_path, 260
+    GetFullPathNameA path, 260, varptr(full_path), offset
+    return full_path
+
 #global
 
 #endif


### PR DESCRIPTION
- ディレクトリだけでなく、テストスクリプトへのパスを指定できる機能を追加
  - スクリプト単体のテストを実行をできるようにした
- 複数のディレクトリやファイルのパスを指定する機能を追加
  - 一度のhsptest実行で複数フォルダ、テストスクリプトを一気に実行できるようにした